### PR TITLE
Add example of accessing request via Ether from faucet and storing in wallet

### DIFF
--- a/cdp-langchain/examples/chatbot/chatbot.py
+++ b/cdp-langchain/examples/chatbot/chatbot.py
@@ -140,4 +140,17 @@ def main():
 
 if __name__ == "__main__":
     print("Starting Agent...")
+
+    # Example of how to access a request via Ether from a faucet and store it in the wallet
+    agent_executor, config = initialize_agent()
+    user_input = "Request test tokens from the faucet"
+    for chunk in agent_executor.stream(
+        {"messages": [HumanMessage(content=user_input)]}, config
+    ):
+        if "agent" in chunk:
+            print(chunk["agent"]["messages"][0].content)
+        elif "tools" in chunk:
+            print(chunk["tools"]["messages"][0].content)
+        print("-------------------")
+
     main()


### PR DESCRIPTION
Add an example of how to access a request via Ether from a faucet and store it in the wallet.

* Add code to `cdp-langchain/examples/chatbot/chatbot.py` to demonstrate how to request test tokens from a faucet and store them in the wallet using the `request_faucet_funds` function from the `CdpToolkit` class.
* Print the response messages from the agent and tools during the request process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/brianyang/cdp-agentkit/pull/1?shareId=e561b84b-3224-4734-b8e7-198455ac72fe).